### PR TITLE
Code Cleanup

### DIFF
--- a/ISIS Integrity - Solutions Installation System/src/com/is2300/isis/utils/ResourceExporter.java
+++ b/ISIS Integrity - Solutions Installation System/src/com/is2300/isis/utils/ResourceExporter.java
@@ -31,23 +31,6 @@ public class ResourceExporter {
     
     public static String exportResource(String resourceName, Class cls, 
                     String outPath, int startPoint) throws Exception {
-        /* DATE:    September 3, 2019
-         * AUTHOR:  Sean Carrick
-         * REASON:  Thanks to comment on StackOverflow, I was slapped in the 
-         *          head due to the fact that I was trying to load a resource
-         *          as a File, which cannot be done directly. I first need to 
-         *          get the URL of the resource, convert that to a URI, then
-         *          create the File object.
-         */
-//        URL url = new URL(cls.getResource(
-//                cls.getResource(cls.getSimpleName() +
-//                ".class").toString().substring(
-//                startPoint, cls.getResource(
-//                cls.getSimpleName() + ".class").toString().lastIndexOf("/")
-//                + 1)) + "files");
-//        URL url = cls.getClass().getResource(resourceName);
-//        URL url = ClassLoader.getSystemResource(resourceName);
-//        File files = new File(url.toURI());
 
         InputStream in = ClassLoader.getSystemClassLoader().getSystemResourceAsStream(resourceName);
         FileOutputStream out = new FileOutputStream(outPath + 


### PR DESCRIPTION
# Bug Fix or Feature Request
- [ ] Bug Fix ( Issue #  )
- [ ] Feature Request ( Issue #  )

## Root Cause
During work trying to copy an internal resource out of the JAR file into a file on disk, I had tried many different solutions before finding one that worked. I commented out the last block of code that had failed, because it was somewhat complex, so I didn't want to delete it, just in case it was close to what I was attempting to do.

## Solution Details
There was no issue that caused me to make this edit. I just wanted to clean that commented code out of the file, so that the code is easier to read.

# Unit Tests Performed
- [ ] Yes ( JUnit )
- [ ] No ( Project Runs )
- [X] No ( No Testing )

## Test Performed
Describe all tests performed on the code either by using `JUnit` or project runs.

**Is more testing required?** 
- [ ] Yes ( **If so, what testing?**   )  
- [X] No  ( **If not, why not?**   ) No tests performed from the deleted code, as it was all comments and wouldn't change the execution of the program.

## Pre-Change Code Snippet
```java
//        URL url = new URL(cls.getResource(
//                cls.getResource(cls.getSimpleName() +
//                ".class").toString().substring(
//                startPoint, cls.getResource(
//                cls.getSimpleName() + ".class").toString().lastIndexOf("/")
//                + 1)) + "files");
//        URL url = cls.getClass().getResource(resourceName);
//        URL url = ClassLoader.getSystemResource(resourceName);
//        File files = new File(url.toURI());
```

## Post-Change Code Snippet
```java
        InputStream in = ClassLoader.getSystemClassLoader().getSystemResourceAsStream(resourceName);
        FileOutputStream out = new FileOutputStream(outPath + 
                        resourceName.substring(resourceName.lastIndexOf("/")));
```
